### PR TITLE
Fixed Documentation Typo

### DIFF
--- a/src/RestfulRouting.Documentation/Views/RouteSet/Show.cshtml
+++ b/src/RestfulRouting.Documentation/Views/RouteSet/Show.cshtml
@@ -14,7 +14,7 @@
 
 <section id="basics">
 <h2>The Basics</h2>
-<p><strong>A RoutSet is a collection of route mappings. It nor only define routes in your application, but can connect to other RouteSets.</strong></p>
+<p><strong>A RouteSet is a collection of route mappings. It nor only define routes in your application, but can connect to other RouteSets.</strong></p>
 <p>All routes are defined inside the Map method of a RouteSet.</p>
 <pre class="prettyprint linenums">
 public class Routes : RouteSet


### PR DESCRIPTION
Fixed a small documentation typo on the routeset view,
right under the basic heading. RoutSet instead of RouteSet.